### PR TITLE
Add sync script for Windows 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoi
 Register-ScheduledTask -Action $action -Trigger $trigger -Principal $principal -Settings $settings -TaskName "SyncProjectTask" -Description "Sync the /home/project directory with a local directory"
 ```
 
+### Referencing the WebContainer in the .ps1 Script
+
+To reference the WebContainer in the `sync_project.ps1` script, you can use the path `/home/project` as the source directory. This path points to the `~/projects` directory in the WebContainer environment. When running the script, make sure to specify this path as the source directory.
+
+For example:
+
+```powershell
+.\sync_project.ps1 -sourceDir "/home/project" -targetDir "C:\path\to\target\directory"
+```
+
 ## Available Scripts
 
 - `pnpm run dev`: Starts the development server.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ When you add a new model to the MODEL_LIST array, it will immediately be availab
 
 ## Using the sync_project.ps1 Script
 
-You can use the `sync_project.ps1` script to sync the `/project` directory with a local directory on your host PC. This script uses `robocopy` to copy files between the WebContainer and your local directory. You can also automate this process using a scheduled task.
+You can use the `sync_project.ps1` script to sync the `/home/project` directory with a local directory on your host PC. This script uses `robocopy` to copy files between the WebContainer and your local directory. You can also automate this process using a scheduled task.
 
 ### Running the Script Manually
 
@@ -97,7 +97,7 @@ $trigger = New-ScheduledTaskTrigger -Daily -At 3am
 $principal = New-ScheduledTaskPrincipal -UserId "SYSTEM" -LogonType ServiceAccount -RunLevel Highest
 $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable
 
-Register-ScheduledTask -Action $action -Trigger $trigger -Principal $principal -Settings $settings -TaskName "SyncProjectTask" -Description "Sync the /project directory with a local directory"
+Register-ScheduledTask -Action $action -Trigger $trigger -Principal $principal -Settings $settings -TaskName "SyncProjectTask" -Description "Sync the /home/project directory with a local directory"
 ```
 
 ## Available Scripts

--- a/README.md
+++ b/README.md
@@ -70,6 +70,36 @@ By default, Anthropic, OpenAI, Groq, and Ollama are implemented as providers, bu
 
 When you add a new model to the MODEL_LIST array, it will immediately be available to use when you run the app locally or reload it. For Ollama models, make sure you have the model installed already before trying to use it here!
 
+## Using the sync_project.ps1 Script
+
+You can use the `sync_project.ps1` script to sync the `/project` directory with a local directory on your host PC. This script uses `robocopy` to copy files between the WebContainer and your local directory. You can also automate this process using a scheduled task.
+
+### Running the Script Manually
+
+1. Open PowerShell as an administrator.
+2. Navigate to the directory where the `sync_project.ps1` script is located.
+3. Run the script with the following command, replacing the paths with your source and target directories:
+
+```powershell
+.\sync_project.ps1 -sourceDir "C:\path\to\source\directory" -targetDir "C:\path\to\target\directory"
+```
+
+### Setting Up a Scheduled Task
+
+To automate the sync process, you can set up a scheduled task that runs the `sync_project.ps1` script daily at a specified time.
+
+1. Open PowerShell as an administrator.
+2. Run the following command to create a scheduled task that runs the script daily at 3 AM:
+
+```powershell
+$action = New-ScheduledTaskAction -Execute "PowerShell.exe" -Argument "-File `"$PSScriptRoot\sync_project.ps1`""
+$trigger = New-ScheduledTaskTrigger -Daily -At 3am
+$principal = New-ScheduledTaskPrincipal -UserId "SYSTEM" -LogonType ServiceAccount -RunLevel Highest
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable
+
+Register-ScheduledTask -Action $action -Trigger $trigger -Principal $principal -Settings $settings -TaskName "SyncProjectTask" -Description "Sync the /project directory with a local directory"
+```
+
 ## Available Scripts
 
 - `pnpm run dev`: Starts the development server.

--- a/scripts/sync_project.ps1
+++ b/scripts/sync_project.ps1
@@ -1,0 +1,15 @@
+param (
+    [string]$sourceDir = "C:\path\to\source\directory",
+    [string]$targetDir = "C:\path\to\target\directory"
+)
+
+# Sync the /project directory with a local directory using robocopy
+robocopy $sourceDir $targetDir /MIR
+
+# Add a scheduled task to automate the sync process
+$action = New-ScheduledTaskAction -Execute "PowerShell.exe" -Argument "-File `"$PSScriptRoot\sync_project.ps1`""
+$trigger = New-ScheduledTaskTrigger -Daily -At 3am
+$principal = New-ScheduledTaskPrincipal -UserId "SYSTEM" -LogonType ServiceAccount -RunLevel Highest
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable
+
+Register-ScheduledTask -Action $action -Trigger $trigger -Principal $principal -Settings $settings -TaskName "SyncProjectTask" -Description "Sync the /project directory with a local directory"

--- a/scripts/sync_project.ps1
+++ b/scripts/sync_project.ps1
@@ -3,7 +3,7 @@ param (
     [string]$targetDir = "C:\path\to\target\directory"
 )
 
-# Sync the /project directory with a local directory using robocopy
+# Sync the ~/projects directory with a local directory using robocopy
 robocopy $sourceDir $targetDir /MIR
 
 # Add a scheduled task to automate the sync process
@@ -12,4 +12,4 @@ $trigger = New-ScheduledTaskTrigger -Daily -At 3am
 $principal = New-ScheduledTaskPrincipal -UserId "SYSTEM" -LogonType ServiceAccount -RunLevel Highest
 $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable
 
-Register-ScheduledTask -Action $action -Trigger $trigger -Principal $principal -Settings $settings -TaskName "SyncProjectTask" -Description "Sync the /project directory with a local directory"
+Register-ScheduledTask -Action $action -Trigger $trigger -Principal $principal -Settings $settings -TaskName "SyncProjectTask" -Description "Sync the ~/projects directory with a local directory"


### PR DESCRIPTION
Add a PowerShell script to sync the `/project` directory with a local directory and automate the process using a scheduled task.

* **scripts/sync_project.ps1**
  - Create a PowerShell script to sync the `/project` directory with a local directory using `robocopy`.
  - Add a scheduled task to automate the sync process daily at 3 AM.

* **README.md**
  - Add instructions on how to use the `sync_project.ps1` script.
  - Include details on setting up the scheduled task to automate the sync process.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/emcconnell/bolt.new-any-llm?shareId=11609f08-f376-4c6d-9cd5-58f7e0a2e614).